### PR TITLE
remove unecessary mbstring package

### DIFF
--- a/images/php/Dockerfile
+++ b/images/php/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.2-fpm-alpine
 # lumen packages
-RUN docker-php-ext-install mbstring tokenizer mysqli pdo_mysql
+RUN docker-php-ext-install tokenizer mysqli pdo_mysql
 # memcached
 ENV MEMCACHED_DEPS zlib-dev libmemcached-dev cyrus-sasl-dev
 RUN apk add --no-cache --update libmemcached-libs zlib


### PR DESCRIPTION
because in the used docker image, mbstring is already installed and configured